### PR TITLE
Updated dead SWAT group link

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -8,7 +8,7 @@ UseTheSource is a collection of open-source projects related to [metaprogramming
 
 ### Contributors
 
-UseTheSource is an initiative from [Centrum Wiskunde & Informatica (CWI)](http://www.cwi.nl/), [SWAT group](http://www.cwi.nl/software-analysis-and-transformation), in Amsterdam (The Netherlands). The code and other artifacts on UseTheSource is contributed by different people from different institutes, such as Universiteit van Amsterdam, TU Eindhoven, NFI, East Carolina University, University of Bergen.
+UseTheSource is an initiative from [Centrum Wiskunde & Informatica (CWI)](http://www.cwi.nl/), [SWAT group](https://www.cwi.nl/research/groups/software-analysis-and-transformation), in Amsterdam (The Netherlands). The code and other artifacts on UseTheSource is contributed by different people from different institutes, such as Universiteit van Amsterdam, TU Eindhoven, NFI, East Carolina University, University of Bergen.
 Find out who they are [here on github](https://github.com/orgs/usethesource/people).
 
 ### Documents


### PR DESCRIPTION
Changed (dead) link https://www.cwi.nl/software-analysis-and-transformation to https://www.cwi.nl/research/groups/software-analysis-and-transformation