### PR TITLE
Fixed incorrect version in blog post title

### DIFF
--- a/_posts/2022-12-21-rascal-0-28-x-release-notes.md
+++ b/_posts/2022-12-21-rascal-0-28-x-release-notes.md
@@ -3,7 +3,7 @@ layout: post
 published: true
 author: "Jurgen J. Vinju"
 authorlink: "http://www.rascal-mpl.org"
-title: "Rascal 0.26.x release notes"
+title: "Rascal 0.28.x release notes"
 ---
 
 In this post we report on the Rascal release 0.28.x


### PR DESCRIPTION
Title still referred to this patch as being 0.26.x instead of 0.28.x